### PR TITLE
feat: implement EvaluationRegistry for on-chain agent evaluation records

### DIFF
--- a/contracts/solidity/script/DeployRegistry.s.sol
+++ b/contracts/solidity/script/DeployRegistry.s.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Script, console} from "forge-std/Script.sol";
+import {EvaluationRegistry} from "../src/EvaluationRegistry.sol";
+
+contract DeployRegistryScript is Script {
+    function setUp() public {}
+
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address stylusVerifier = vm.envAddress("STYLUS_VERIFIER_V4");
+
+        console.log("========================================");
+        console.log("  EvaluationRegistry - Deployment");
+        console.log("========================================");
+        console.log("");
+        console.log("Deployer:", vm.addr(deployerPrivateKey));
+        console.log("Chain ID:", block.chainid);
+        console.log("Stylus Verifier:", stylusVerifier);
+        console.log("");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        EvaluationRegistry registry = new EvaluationRegistry(stylusVerifier);
+
+        vm.stopBroadcast();
+
+        console.log("========================================");
+        console.log("  Deployment Successful!");
+        console.log("========================================");
+        console.log("EvaluationRegistry deployed at:", address(registry));
+        console.log("");
+        console.log("Update lib/contracts.ts with:");
+        console.log("  EVALUATION_REGISTRY_ADDRESS =", address(registry));
+    }
+}

--- a/contracts/solidity/src/EvaluationRegistry.sol
+++ b/contracts/solidity/src/EvaluationRegistry.sol
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @notice Interface for the Stylus STARK verifier contract
+interface IStylusVerifier {
+    /// @notice Verify a Sharpe ratio STARK proof
+    /// @param publicInputs Public inputs [num_trades, scale, sharpe_sq_scaled, trace_hash]
+    /// @param commitments Merkle commitments [trace_root, comp_root, fri_roots...]
+    /// @param oodValues Out-of-domain evaluation values
+    /// @param friFinalPoly Final FRI polynomial coefficients
+    /// @param queryValues Flattened query data
+    /// @param queryPaths Flattened Merkle paths
+    /// @param queryMetadata Query metadata [num_queries, num_fri_layers, ...]
+    /// @return valid Whether the proof is valid
+    function verifySharpeProof(
+        uint256[] calldata publicInputs,
+        uint256[] calldata commitments,
+        uint256[] calldata oodValues,
+        uint256[] calldata friFinalPoly,
+        uint256[] calldata queryValues,
+        uint256[] calldata queryPaths,
+        uint256[] calldata queryMetadata
+    ) external returns (bool valid);
+}
+
+/// @title EvaluationRegistry - On-chain agent evaluation record registry
+/// @notice Stores agent evaluation results with STARK proof verification via Stylus verifier
+/// @dev Phase 2 contract: submit + verify in 1 tx, tracks best scores and rankings
+contract EvaluationRegistry {
+    /// @notice Evaluation record for a single agent submission
+    struct EvaluationRecord {
+        address agentId;
+        bytes32 datasetCommitment;
+        uint256 tradeCount;
+        uint256 sharpeSqBps;
+        uint256 totalReturnBps;
+        bytes32 proofHash;
+        uint256 blockNumber;
+        address evaluator;
+        uint256 timestamp;
+        bool verified;
+    }
+
+    /// @notice Emitted when an evaluation is submitted
+    /// @param evaluationId The unique evaluation ID
+    /// @param agentId The agent address
+    /// @param evaluator The address that submitted the evaluation
+    /// @param sharpeSqBps The Sharpe^2 score in basis points
+    /// @param verified Whether the STARK proof was verified
+    event EvaluationSubmitted(
+        uint256 indexed evaluationId,
+        address indexed agentId,
+        address indexed evaluator,
+        uint256 sharpeSqBps,
+        bool verified
+    );
+
+    /// @notice Emitted when an agent's best score is updated
+    /// @param agentId The agent address
+    /// @param newBestSharpeSqBps The new best Sharpe^2 score
+    /// @param evaluationId The evaluation ID that set the new best
+    event BestScoreUpdated(
+        address indexed agentId,
+        uint256 newBestSharpeSqBps,
+        uint256 evaluationId
+    );
+
+    /// @notice The Stylus verifier contract used for STARK proof verification
+    IStylusVerifier public immutable stylusVerifier;
+
+    /// @dev Next evaluation ID counter (starts at 1)
+    uint256 private _nextEvaluationId = 1;
+
+    /// @dev Mapping from evaluation ID to record
+    mapping(uint256 => EvaluationRecord) private _evaluations;
+
+    /// @dev Mapping from agent address to list of evaluation IDs
+    mapping(address => uint256[]) private _agentEvaluationIds;
+
+    /// @dev Mapping from agent address to best Sharpe^2 score (bps)
+    mapping(address => uint256) private _bestSharpeSqBps;
+
+    /// @dev Array of agent addresses that have at least one verified evaluation
+    address[] private _rankedAgents;
+
+    /// @dev Whether an agent has been added to the ranked agents list
+    mapping(address => bool) private _hasEvaluation;
+
+    /// @dev Whether a proof hash has already been submitted (duplicate prevention)
+    mapping(bytes32 => bool) private _proofSubmitted;
+
+    /// @param _stylusVerifier Address of the deployed Stylus STARK verifier
+    constructor(address _stylusVerifier) {
+        stylusVerifier = IStylusVerifier(_stylusVerifier);
+    }
+
+    /// @notice Submit an evaluation with STARK proof for verification
+    /// @dev Calls Stylus verifier via try/catch; records verified=false on failure
+    /// @param agentId The agent address being evaluated
+    /// @param publicInputs Public inputs [num_trades, scale, sharpe_sq_scaled, trace_hash]
+    /// @param commitments Merkle commitments
+    /// @param oodValues Out-of-domain values
+    /// @param friFinalPoly Final FRI polynomial
+    /// @param queryValues Query values
+    /// @param queryPaths Query Merkle paths
+    /// @param queryMetadata Query metadata
+    /// @return evaluationId The assigned evaluation ID
+    function submitEvaluation(
+        address agentId,
+        uint256[] calldata publicInputs,
+        uint256[] calldata commitments,
+        uint256[] calldata oodValues,
+        uint256[] calldata friFinalPoly,
+        uint256[] calldata queryValues,
+        uint256[] calldata queryPaths,
+        uint256[] calldata queryMetadata
+    ) external returns (uint256 evaluationId) {
+        require(agentId != address(0), "Agent address cannot be zero");
+        require(publicInputs.length == 4, "Public inputs must have 4 elements");
+
+        // Compute proof hash for duplicate prevention
+        bytes32 proofHash = keccak256(
+            abi.encode(
+                publicInputs,
+                commitments,
+                oodValues,
+                friFinalPoly,
+                queryValues,
+                queryPaths,
+                queryMetadata
+            )
+        );
+        require(!_proofSubmitted[proofHash], "Proof already submitted");
+        _proofSubmitted[proofHash] = true;
+
+        // Attempt verification via Stylus verifier
+        bool verified;
+        try
+            stylusVerifier.verifySharpeProof(
+                publicInputs,
+                commitments,
+                oodValues,
+                friFinalPoly,
+                queryValues,
+                queryPaths,
+                queryMetadata
+            )
+        returns (bool result) {
+            verified = result;
+        } catch {
+            verified = false;
+        }
+
+        // Parse public inputs
+        uint256 tradeCount = publicInputs[0];
+        uint256 totalReturnBps = publicInputs[1];
+        uint256 sharpeSqBps = publicInputs[2];
+        bytes32 datasetCommitment = bytes32(publicInputs[3]);
+
+        // Store evaluation record
+        evaluationId = _nextEvaluationId++;
+        _evaluations[evaluationId] = EvaluationRecord({
+            agentId: agentId,
+            datasetCommitment: datasetCommitment,
+            tradeCount: tradeCount,
+            sharpeSqBps: sharpeSqBps,
+            totalReturnBps: totalReturnBps,
+            proofHash: proofHash,
+            blockNumber: block.number,
+            evaluator: msg.sender,
+            timestamp: block.timestamp,
+            verified: verified
+        });
+        _agentEvaluationIds[agentId].push(evaluationId);
+
+        // Update ranking only for verified evaluations
+        if (verified) {
+            _updateRanking(agentId, sharpeSqBps, evaluationId);
+        }
+
+        emit EvaluationSubmitted(evaluationId, agentId, msg.sender, sharpeSqBps, verified);
+    }
+
+    /// @notice Get the top-ranked agents by best Sharpe^2 score
+    /// @param limit Maximum number of agents to return
+    /// @return agents Array of agent addresses (descending by score)
+    /// @return scores Array of corresponding best scores
+    function getTopAgents(
+        uint256 limit
+    ) external view returns (address[] memory agents, uint256[] memory scores) {
+        uint256 total = _rankedAgents.length;
+        uint256 count = limit < total ? limit : total;
+
+        // Copy to memory for sorting
+        address[] memory allAgents = new address[](total);
+        uint256[] memory allScores = new uint256[](total);
+        for (uint256 i = 0; i < total; i++) {
+            allAgents[i] = _rankedAgents[i];
+            allScores[i] = _bestSharpeSqBps[_rankedAgents[i]];
+        }
+
+        // Selection sort: find top `count` in descending order
+        for (uint256 i = 0; i < count; i++) {
+            uint256 maxIdx = i;
+            for (uint256 j = i + 1; j < total; j++) {
+                if (allScores[j] > allScores[maxIdx]) {
+                    maxIdx = j;
+                }
+            }
+            if (maxIdx != i) {
+                // Swap scores
+                (allScores[i], allScores[maxIdx]) = (allScores[maxIdx], allScores[i]);
+                // Swap agents
+                (allAgents[i], allAgents[maxIdx]) = (allAgents[maxIdx], allAgents[i]);
+            }
+        }
+
+        // Build result arrays
+        agents = new address[](count);
+        scores = new uint256[](count);
+        for (uint256 i = 0; i < count; i++) {
+            agents[i] = allAgents[i];
+            scores[i] = allScores[i];
+        }
+    }
+
+    /// @notice Get all evaluations for a specific agent
+    /// @param agentId The agent address
+    /// @return records Array of evaluation records
+    function getAgentEvaluations(
+        address agentId
+    ) external view returns (EvaluationRecord[] memory records) {
+        uint256[] storage ids = _agentEvaluationIds[agentId];
+        records = new EvaluationRecord[](ids.length);
+        for (uint256 i = 0; i < ids.length; i++) {
+            records[i] = _evaluations[ids[i]];
+        }
+    }
+
+    /// @notice Get a single evaluation by ID
+    /// @param evaluationId The evaluation ID
+    /// @return record The evaluation record
+    function getEvaluation(
+        uint256 evaluationId
+    ) external view returns (EvaluationRecord memory record) {
+        return _evaluations[evaluationId];
+    }
+
+    /// @notice Get the total number of evaluations submitted
+    /// @return count The evaluation count
+    function getEvaluationCount() external view returns (uint256 count) {
+        return _nextEvaluationId - 1;
+    }
+
+    /// @notice Get the best Sharpe^2 score for an agent
+    /// @param agentId The agent address
+    /// @return score The best score in basis points
+    function getBestScore(address agentId) external view returns (uint256 score) {
+        return _bestSharpeSqBps[agentId];
+    }
+
+    /// @dev Update the ranking when a verified evaluation has a new best score
+    /// @param agentId The agent address
+    /// @param sharpeSqBps The new score
+    /// @param evaluationId The evaluation that produced this score
+    function _updateRanking(address agentId, uint256 sharpeSqBps, uint256 evaluationId) private {
+        if (!_hasEvaluation[agentId]) {
+            _hasEvaluation[agentId] = true;
+            _rankedAgents.push(agentId);
+        }
+
+        if (sharpeSqBps > _bestSharpeSqBps[agentId]) {
+            _bestSharpeSqBps[agentId] = sharpeSqBps;
+            emit BestScoreUpdated(agentId, sharpeSqBps, evaluationId);
+        }
+    }
+}

--- a/contracts/solidity/test/EvaluationRegistry.t.sol
+++ b/contracts/solidity/test/EvaluationRegistry.t.sol
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../src/EvaluationRegistry.sol";
+
+/// @notice Mock Stylus verifier that returns a configurable result
+contract MockStylusVerifier is IStylusVerifier {
+    bool public shouldVerify;
+
+    constructor(bool _shouldVerify) {
+        shouldVerify = _shouldVerify;
+    }
+
+    function verifySharpeProof(
+        uint256[] calldata,
+        uint256[] calldata,
+        uint256[] calldata,
+        uint256[] calldata,
+        uint256[] calldata,
+        uint256[] calldata,
+        uint256[] calldata
+    ) external view override returns (bool) {
+        return shouldVerify;
+    }
+}
+
+/// @notice Mock Stylus verifier that always reverts
+contract RevertingVerifier is IStylusVerifier {
+    function verifySharpeProof(
+        uint256[] calldata,
+        uint256[] calldata,
+        uint256[] calldata,
+        uint256[] calldata,
+        uint256[] calldata,
+        uint256[] calldata,
+        uint256[] calldata
+    ) external pure override returns (bool) {
+        revert("Verifier error");
+    }
+}
+
+contract EvaluationRegistryTest is Test {
+    EvaluationRegistry public registry;
+    EvaluationRegistry public unverifiedRegistry;
+    EvaluationRegistry public revertingRegistry;
+
+    MockStylusVerifier public verifier;
+    MockStylusVerifier public falseVerifier;
+    RevertingVerifier public revertVerifier;
+
+    address constant AGENT_A = address(0xA);
+    address constant AGENT_B = address(0xB);
+    address constant AGENT_C = address(0xC);
+    address constant AGENT_D = address(0xD);
+    address constant AGENT_E = address(0xE);
+
+    function setUp() public {
+        verifier = new MockStylusVerifier(true);
+        falseVerifier = new MockStylusVerifier(false);
+        revertVerifier = new RevertingVerifier();
+
+        registry = new EvaluationRegistry(address(verifier));
+        unverifiedRegistry = new EvaluationRegistry(address(falseVerifier));
+        revertingRegistry = new EvaluationRegistry(address(revertVerifier));
+    }
+
+    /// @dev Helper to build dummy proof arrays with a unique seed
+    function _makeProof(
+        uint256 tradeCount,
+        uint256 totalReturn,
+        uint256 sharpeSq,
+        uint256 merkleRoot,
+        uint256 seed
+    )
+        internal
+        pure
+        returns (
+            uint256[] memory publicInputs,
+            uint256[] memory commitments,
+            uint256[] memory oodValues,
+            uint256[] memory friFinalPoly,
+            uint256[] memory queryValues,
+            uint256[] memory queryPaths,
+            uint256[] memory queryMetadata
+        )
+    {
+        publicInputs = new uint256[](4);
+        publicInputs[0] = tradeCount;
+        publicInputs[1] = totalReturn;
+        publicInputs[2] = sharpeSq;
+        publicInputs[3] = merkleRoot;
+
+        commitments = new uint256[](2);
+        commitments[0] = seed;
+        commitments[1] = seed + 1;
+
+        oodValues = new uint256[](1);
+        oodValues[0] = seed + 2;
+
+        friFinalPoly = new uint256[](1);
+        friFinalPoly[0] = seed + 3;
+
+        queryValues = new uint256[](1);
+        queryValues[0] = seed + 4;
+
+        queryPaths = new uint256[](1);
+        queryPaths[0] = seed + 5;
+
+        queryMetadata = new uint256[](1);
+        queryMetadata[0] = seed + 6;
+    }
+
+    /// @notice Test: verified submission stores all fields correctly and emits event
+    function test_submitEvaluation_verified() public {
+        (
+            uint256[] memory pi,
+            uint256[] memory cm,
+            uint256[] memory ood,
+            uint256[] memory fri,
+            uint256[] memory qv,
+            uint256[] memory qp,
+            uint256[] memory qm
+        ) = _makeProof(15, 500, 2500, 0xABCD, 100);
+
+        vm.expectEmit(true, true, true, true);
+        emit EvaluationRegistry.EvaluationSubmitted(1, AGENT_A, address(this), 2500, true);
+
+        uint256 id = registry.submitEvaluation(AGENT_A, pi, cm, ood, fri, qv, qp, qm);
+        assertEq(id, 1, "First evaluation should have ID 1");
+
+        EvaluationRegistry.EvaluationRecord memory rec = registry.getEvaluation(1);
+        assertEq(rec.agentId, AGENT_A);
+        assertEq(rec.tradeCount, 15);
+        assertEq(rec.sharpeSqBps, 2500);
+        assertEq(rec.totalReturnBps, 500);
+        assertEq(rec.evaluator, address(this));
+        assertTrue(rec.verified);
+        assertEq(rec.blockNumber, block.number);
+        assertEq(rec.timestamp, block.timestamp);
+        assertEq(rec.datasetCommitment, bytes32(uint256(0xABCD)));
+
+        assertEq(registry.getEvaluationCount(), 1);
+        assertEq(registry.getBestScore(AGENT_A), 2500);
+    }
+
+    /// @notice Test: unverified submission stores verified=false and does not update ranking
+    function test_submitEvaluation_unverified() public {
+        (
+            uint256[] memory pi,
+            uint256[] memory cm,
+            uint256[] memory ood,
+            uint256[] memory fri,
+            uint256[] memory qv,
+            uint256[] memory qp,
+            uint256[] memory qm
+        ) = _makeProof(10, 300, 1000, 0x1234, 200);
+
+        uint256 id = unverifiedRegistry.submitEvaluation(AGENT_A, pi, cm, ood, fri, qv, qp, qm);
+        assertEq(id, 1);
+
+        EvaluationRegistry.EvaluationRecord memory rec = unverifiedRegistry.getEvaluation(1);
+        assertFalse(rec.verified);
+
+        // Ranking should not be updated for unverified
+        (address[] memory agents, ) = unverifiedRegistry.getTopAgents(10);
+        assertEq(agents.length, 0, "No agents should be ranked for unverified submissions");
+        assertEq(unverifiedRegistry.getBestScore(AGENT_A), 0);
+    }
+
+    /// @notice Test: revert on zero agent address
+    function test_revertOnZeroAgent() public {
+        (
+            uint256[] memory pi,
+            uint256[] memory cm,
+            uint256[] memory ood,
+            uint256[] memory fri,
+            uint256[] memory qv,
+            uint256[] memory qp,
+            uint256[] memory qm
+        ) = _makeProof(5, 100, 500, 0xDEAD, 300);
+
+        vm.expectRevert("Agent address cannot be zero");
+        registry.submitEvaluation(address(0), pi, cm, ood, fri, qv, qp, qm);
+    }
+
+    /// @notice Test: revert on invalid public inputs length
+    function test_revertOnInvalidPublicInputs() public {
+        uint256[] memory pi = new uint256[](3); // wrong length
+        uint256[] memory cm = new uint256[](1);
+        uint256[] memory ood = new uint256[](1);
+        uint256[] memory fri = new uint256[](1);
+        uint256[] memory qv = new uint256[](1);
+        uint256[] memory qp = new uint256[](1);
+        uint256[] memory qm = new uint256[](1);
+
+        vm.expectRevert("Public inputs must have 4 elements");
+        registry.submitEvaluation(AGENT_A, pi, cm, ood, fri, qv, qp, qm);
+    }
+
+    /// @notice Test: revert on duplicate proof submission
+    function test_revertOnDuplicateProof() public {
+        (
+            uint256[] memory pi,
+            uint256[] memory cm,
+            uint256[] memory ood,
+            uint256[] memory fri,
+            uint256[] memory qv,
+            uint256[] memory qp,
+            uint256[] memory qm
+        ) = _makeProof(10, 200, 800, 0xBEEF, 400);
+
+        registry.submitEvaluation(AGENT_A, pi, cm, ood, fri, qv, qp, qm);
+
+        vm.expectRevert("Proof already submitted");
+        registry.submitEvaluation(AGENT_A, pi, cm, ood, fri, qv, qp, qm);
+    }
+
+    /// @notice Test: multiple evaluations for same agent are tracked correctly
+    function test_getAgentEvaluations_multiple() public {
+        for (uint256 i = 0; i < 3; i++) {
+            (
+                uint256[] memory pi,
+                uint256[] memory cm,
+                uint256[] memory ood,
+                uint256[] memory fri,
+                uint256[] memory qv,
+                uint256[] memory qp,
+                uint256[] memory qm
+            ) = _makeProof(10 + i, 100 + i, 500 + i * 100, 0xAAAA + i, 500 + i * 10);
+
+            registry.submitEvaluation(AGENT_A, pi, cm, ood, fri, qv, qp, qm);
+        }
+
+        EvaluationRegistry.EvaluationRecord[] memory records =
+            registry.getAgentEvaluations(AGENT_A);
+        assertEq(records.length, 3, "Should have 3 evaluations");
+        assertEq(records[0].tradeCount, 10);
+        assertEq(records[1].tradeCount, 11);
+        assertEq(records[2].tradeCount, 12);
+    }
+
+    /// @notice Test: getTopAgents returns correct descending ranking for 5 agents, top 3
+    function test_getTopAgents_ranking() public {
+        address[5] memory agents = [AGENT_A, AGENT_B, AGENT_C, AGENT_D, AGENT_E];
+        uint256[5] memory scores = [uint256(300), 500, 100, 400, 200];
+
+        for (uint256 i = 0; i < 5; i++) {
+            (
+                uint256[] memory pi,
+                uint256[] memory cm,
+                uint256[] memory ood,
+                uint256[] memory fri,
+                uint256[] memory qv,
+                uint256[] memory qp,
+                uint256[] memory qm
+            ) = _makeProof(10, 100, scores[i], 0xF000 + i, 600 + i * 10);
+
+            registry.submitEvaluation(agents[i], pi, cm, ood, fri, qv, qp, qm);
+        }
+
+        (address[] memory topAgents, uint256[] memory topScores) = registry.getTopAgents(3);
+
+        assertEq(topAgents.length, 3, "Should return 3 agents");
+        // Descending order: B(500), D(400), A(300)
+        assertEq(topAgents[0], AGENT_B);
+        assertEq(topScores[0], 500);
+        assertEq(topAgents[1], AGENT_D);
+        assertEq(topScores[1], 400);
+        assertEq(topAgents[2], AGENT_A);
+        assertEq(topScores[2], 300);
+    }
+
+    /// @notice Test: best score only updates when new score is higher
+    function test_bestScoreUpdate() public {
+        // First submission: score 200
+        (
+            uint256[] memory pi1,
+            uint256[] memory cm1,
+            uint256[] memory ood1,
+            uint256[] memory fri1,
+            uint256[] memory qv1,
+            uint256[] memory qp1,
+            uint256[] memory qm1
+        ) = _makeProof(10, 100, 200, 0x1111, 700);
+        registry.submitEvaluation(AGENT_A, pi1, cm1, ood1, fri1, qv1, qp1, qm1);
+        assertEq(registry.getBestScore(AGENT_A), 200);
+
+        // Second submission: lower score 100 — should NOT update
+        (
+            uint256[] memory pi2,
+            uint256[] memory cm2,
+            uint256[] memory ood2,
+            uint256[] memory fri2,
+            uint256[] memory qv2,
+            uint256[] memory qp2,
+            uint256[] memory qm2
+        ) = _makeProof(10, 100, 100, 0x2222, 800);
+        registry.submitEvaluation(AGENT_A, pi2, cm2, ood2, fri2, qv2, qp2, qm2);
+        assertEq(registry.getBestScore(AGENT_A), 200, "Best score should not decrease");
+
+        // Third submission: higher score 500 — should update
+        (
+            uint256[] memory pi3,
+            uint256[] memory cm3,
+            uint256[] memory ood3,
+            uint256[] memory fri3,
+            uint256[] memory qv3,
+            uint256[] memory qp3,
+            uint256[] memory qm3
+        ) = _makeProof(10, 100, 500, 0x3333, 900);
+        registry.submitEvaluation(AGENT_A, pi3, cm3, ood3, fri3, qv3, qp3, qm3);
+        assertEq(registry.getBestScore(AGENT_A), 500, "Best score should update to higher value");
+    }
+
+    /// @notice Test: reverting verifier records unverified evaluation
+    function test_verifierReverts_recordsUnverified() public {
+        (
+            uint256[] memory pi,
+            uint256[] memory cm,
+            uint256[] memory ood,
+            uint256[] memory fri,
+            uint256[] memory qv,
+            uint256[] memory qp,
+            uint256[] memory qm
+        ) = _makeProof(20, 400, 3000, 0xCAFE, 1000);
+
+        uint256 id =
+            revertingRegistry.submitEvaluation(AGENT_A, pi, cm, ood, fri, qv, qp, qm);
+        assertEq(id, 1);
+
+        EvaluationRegistry.EvaluationRecord memory rec = revertingRegistry.getEvaluation(1);
+        assertFalse(rec.verified, "Should be unverified when verifier reverts");
+        assertEq(rec.sharpeSqBps, 3000);
+
+        // Should not appear in ranking
+        (address[] memory agents, ) = revertingRegistry.getTopAgents(10);
+        assertEq(agents.length, 0);
+    }
+}

--- a/lib/contracts.ts
+++ b/lib/contracts.ts
@@ -21,6 +21,10 @@ export const STYLUS_VERIFIER_ADDRESS =
 export const SOLIDITY_VERIFIER_ADDRESS =
   "0x96326E368b6f2fdA258452ac42B1aC013238f5Ce" as const;
 
+// EvaluationRegistry (Phase 2 — agent evaluation on-chain records)
+export const EVALUATION_REGISTRY_ADDRESS =
+  "0x0000000000000000000000000000000000000000" as const;
+
 /**
  * Verifier contract ABI (Poseidon/Merkle benchmark)
  * Shared interface for both Stylus and Solidity implementations
@@ -149,6 +153,120 @@ export const STARK_VERIFIER_ABI = [
 ] as const;
 
 /**
+ * EvaluationRegistry ABI
+ */
+export const EVALUATION_REGISTRY_ABI = [
+  {
+    type: "function",
+    name: "submitEvaluation",
+    inputs: [
+      { name: "agentId", type: "address" },
+      { name: "publicInputs", type: "uint256[]" },
+      { name: "commitments", type: "uint256[]" },
+      { name: "oodValues", type: "uint256[]" },
+      { name: "friFinalPoly", type: "uint256[]" },
+      { name: "queryValues", type: "uint256[]" },
+      { name: "queryPaths", type: "uint256[]" },
+      { name: "queryMetadata", type: "uint256[]" },
+    ],
+    outputs: [{ name: "evaluationId", type: "uint256" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "getTopAgents",
+    inputs: [{ name: "limit", type: "uint256" }],
+    outputs: [
+      { name: "agents", type: "address[]" },
+      { name: "scores", type: "uint256[]" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getAgentEvaluations",
+    inputs: [{ name: "agentId", type: "address" }],
+    outputs: [
+      {
+        name: "records",
+        type: "tuple[]",
+        components: [
+          { name: "agentId", type: "address" },
+          { name: "datasetCommitment", type: "bytes32" },
+          { name: "tradeCount", type: "uint256" },
+          { name: "sharpeSqBps", type: "uint256" },
+          { name: "totalReturnBps", type: "uint256" },
+          { name: "proofHash", type: "bytes32" },
+          { name: "blockNumber", type: "uint256" },
+          { name: "evaluator", type: "address" },
+          { name: "timestamp", type: "uint256" },
+          { name: "verified", type: "bool" },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getEvaluation",
+    inputs: [{ name: "evaluationId", type: "uint256" }],
+    outputs: [
+      {
+        name: "record",
+        type: "tuple",
+        components: [
+          { name: "agentId", type: "address" },
+          { name: "datasetCommitment", type: "bytes32" },
+          { name: "tradeCount", type: "uint256" },
+          { name: "sharpeSqBps", type: "uint256" },
+          { name: "totalReturnBps", type: "uint256" },
+          { name: "proofHash", type: "bytes32" },
+          { name: "blockNumber", type: "uint256" },
+          { name: "evaluator", type: "address" },
+          { name: "timestamp", type: "uint256" },
+          { name: "verified", type: "bool" },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getEvaluationCount",
+    inputs: [],
+    outputs: [{ name: "count", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "getBestScore",
+    inputs: [{ name: "agentId", type: "address" }],
+    outputs: [{ name: "score", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "event",
+    name: "EvaluationSubmitted",
+    inputs: [
+      { name: "evaluationId", type: "uint256", indexed: true },
+      { name: "agentId", type: "address", indexed: true },
+      { name: "evaluator", type: "address", indexed: true },
+      { name: "sharpeSqBps", type: "uint256", indexed: false },
+      { name: "verified", type: "bool", indexed: false },
+    ],
+  },
+  {
+    type: "event",
+    name: "BestScoreUpdated",
+    inputs: [
+      { name: "agentId", type: "address", indexed: true },
+      { name: "newBestSharpeSqBps", type: "uint256", indexed: false },
+      { name: "evaluationId", type: "uint256", indexed: false },
+    ],
+  },
+] as const;
+
+/**
  * TypeScript type for a serialized STARK proof (from prover WASM)
  */
 export interface StarkProofJSON {
@@ -192,6 +310,17 @@ export const getStarkVerifierContract = () =>
     chain: arbitrumSepolia,
     address: STARK_VERIFIER_V4_ADDRESS,
     abi: STARK_VERIFIER_ABI,
+  });
+
+/**
+ * Get EvaluationRegistry contract instance
+ */
+export const getEvaluationRegistryContract = () =>
+  getContract({
+    client,
+    chain: arbitrumSepolia,
+    address: EVALUATION_REGISTRY_ADDRESS,
+    abi: EVALUATION_REGISTRY_ABI,
   });
 
 /**


### PR DESCRIPTION
## Summary
Closes #45

- **EvaluationRegistry.sol**: On-chain registry that records agent evaluation results with STARK proof verification via Stylus verifier (`verifySharpeProof`) in a single transaction using `try/catch`. Unverified/reverted proofs are saved as `verified=false`. Includes `proofHash` duplicate prevention, per-agent best score tracking, and `getTopAgents()` ranking (selection sort, descending).
- **EvaluationRegistry.t.sol**: 9 Foundry tests with `MockStylusVerifier` and `RevertingVerifier` — all passing. Covers verified/unverified submission, zero agent revert, invalid inputs revert, duplicate proof revert, multi-evaluation tracking, top-3 ranking from 5 agents, best score update logic, and reverting verifier graceful handling.
- **DeployRegistry.s.sol**: Registry-specific deployment script (reads `PRIVATE_KEY` and `STYLUS_VERIFIER_V4` env vars).
- **lib/contracts.ts**: Added `EVALUATION_REGISTRY_ADDRESS` (placeholder), `EVALUATION_REGISTRY_ABI` (6 functions + 2 events), and `getEvaluationRegistryContract()` helper.

## Gas Report
| Function | Avg Gas |
|----------|---------|
| `submitEvaluation` | ~318K |
| `getTopAgents` | ~14K |
| `getEvaluation` | ~22K |
| Deployment | ~858K |

## Test plan
- [x] `forge test -vvv --match-contract EvaluationRegistry` — 9/9 passed
- [x] `forge test --gas-report` — gas numbers reasonable
- [ ] Deploy to Arbitrum Sepolia after merge and update placeholder address