### PR TITLE
rename ProofScore to RealBot + update hackathon name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ProofScore — On-chain STARK-verified trading agent evaluation on Arbitrum Stylus. Full STARK pipeline: off-chain prover (Rust, WASM-compatible), on-chain verifier (Stylus Rust/WASM), EvaluationRegistry (Solidity), and a Next.js frontend. Uses Keccak256 (native Stylus precompile) for FRI Merkle commitments and Fiat-Shamir channel. Verifies Sharpe ratio proofs for trading agent performance evaluation.
+RealBot — On-chain STARK-verified trading agent evaluation on Arbitrum Stylus. Full STARK pipeline: off-chain prover (Rust, WASM-compatible), on-chain verifier (Stylus Rust/WASM), EvaluationRegistry (Solidity), and a Next.js frontend. Uses Keccak256 (native Stylus precompile) for FRI Merkle commitments and Fiat-Shamir channel. Verifies Sharpe ratio proofs for trading agent performance evaluation.
 
 ## Common Commands
 

--- a/README.md
+++ b/README.md
@@ -1,82 +1,129 @@
-# ProofScore — On-Chain Agent Evaluation with STARK Proofs
+# RealBot — Trustless Trading Agent Verification on Arbitrum Stylus
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Arbitrum](https://img.shields.io/badge/Arbitrum-Stylus-blue.svg)](https://arbitrum.io/)
 [![Rust](https://img.shields.io/badge/Rust-WASM-orange.svg)](https://www.rust-lang.org/)
 [![Next.js](https://img.shields.io/badge/Next.js-16-black.svg)](https://nextjs.org/)
 
-> **STARK-verified trading agent evaluation on Arbitrum Stylus — Sharpe ratio proofs with zero-knowledge guarantees**
+> **STARK-verified Sharpe ratio proofs for DeFi trading agents — no trusted setup, fully on-chain**
 
-Built for **Arbitrum Buildathon 2026** | Evolved from APAC Mini Hackathon 1st place
-
----
-
-## Overview
-
-ProofScore uses STARK proofs to verify trading agent performance (Sharpe ratio) on-chain. Agents submit their trade data off-chain, generate a STARK proof of their Sharpe ratio computation, and the proof is verified on Arbitrum Stylus. Results are recorded in the EvaluationRegistry smart contract for transparent, trustless agent ranking.
-
-### Key Features
-
-- **STARK-Verified Sharpe Ratio** — Zero-knowledge proof of trading performance metrics
-- **On-Chain Agent Evaluation** — EvaluationRegistry records verified scores per agent
-- **Arbitrum Stylus (Rust/WASM)** — Native Keccak256 precompile for efficient FRI Merkle verification
-- **No Trusted Setup** — Hash-based STARK security, post-quantum ready
-- **Off-Chain Prover** — Rust CLI/WASM prover generates Sharpe proofs
-- **~1.25M Gas** — Sharpe ratio verification (Bot A, 15 trades, 4 queries)
+Built for **Arbitrum Open House NYC: Online Buildathon** | APAC Mini Hackathon 1st Place
 
 ---
 
-## Architecture
+## Problem
+
+DeFi trading agents and bots report their own performance. There is no way to verify these claims:
+
+- **Self-reported returns are easy to fake** — anyone can claim a 200% APY
+- **Centralized leaderboards require trust** — the platform operator can manipulate rankings
+- **No mathematical guarantee** — users have no way to independently verify a Sharpe ratio
+
+RealBot solves this by generating **STARK proofs** of Sharpe ratio computations from real trade data and verifying them **on-chain on Arbitrum Stylus**. The result is a trustless, mathematically verified performance score that no one can forge.
+
+---
+
+## How It Works
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                    Off-Chain Prover (Rust CLI / WASM)             │
-│                                                                  │
-│  1. Build Sharpe trace (6 columns: ret, ret², cum_ret, etc.)     │
-│  2. Evaluate trace on LDE domain (4x blowup)                    │
-│  3. Commit via Keccak256 Merkle trees                            │
-│  4. Fiat-Shamir: draw OOD point z, 9 composition alphas         │
-│  5. Compute composition polynomial on LDE                        │
-│  6. Run FRI protocol (fold + commit each layer)                  │
-│  7. Serialize proof → ABI-encoded calldata                       │
-│                                                                  │
-│  cargo run --features cli --release -- --bot a --num-queries 4   │
-└───────────────────────────────┬─────────────────────────────────┘
-                                │ STARK Proof (calldata)
-                                ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    Arbitrum Sepolia (L2)                          │
-│                      Chain ID: 421614                            │
-├────────────────────────────┬────────────────────────────────────┤
-│     STARK Verifier         │     EvaluationRegistry             │
-│     (Rust → WASM)          │     (Solidity)                     │
-│                            │                                     │
-│  verifySharpeProof()       │  submitEvaluation()                │
-│  - Fiat-Shamir channel     │  getTopAgents()                    │
-│  - Sharpe AIR constraints  │  getAgentEvaluations()             │
-│  - Composition polynomial  │                                     │
-│  - FRI low-degree test     │                                     │
-│                            │                                     │
-│  0x4709cc38...             │  TBD                               │
-└────────────────────────────┴────────────────────────────────────┘
+  Fetch Real Trades        Generate STARK Proof         Verify On-Chain
+  ─────────────────   →    ────────────────────   →    ─────────────────
+   GMX V2 events              Browser WASM              Arbitrum Stylus
+   (Arbitrum One)              (380ms)                   (~1.25M gas)
 ```
 
-### Sharpe Ratio AIR Constraints
+```
+┌──────────────┐     ┌──────────────────────┐     ┌──────────────────────┐
+│   GMX V2     │     │   WASM Prover        │     │   Stylus Verifier    │
+│   Mainnet    │────→│                      │────→│                      │
+│              │     │  Sharpe trace (6 col) │     │  Fiat-Shamir channel │
+│  Trade data  │     │  Keccak256 Merkle     │     │  AIR constraint check│
+│  PnL events  │     │  FRI commitment       │     │  FRI low-degree test │
+│              │     │  Composition poly     │     │  Commitment binding  │
+└──────────────┘     └──────────────────────┘     └──────────────────────┘
+                           STARK Proof
+                        (ABI-encoded calldata)
+```
 
-6 trace columns: `[return, return_sq, cum_ret, cum_sq, trade_count, dataset_commitment]`
+1. **Fetch** — Pull real trade history from GMX V2 on Arbitrum One mainnet
+2. **Prove** — Generate a STARK proof of the Sharpe ratio computation entirely in the browser (WASM)
+3. **Verify** — Submit the proof to the Stylus verifier contract on Arbitrum Sepolia for on-chain verification
 
-**Transition Constraints (5):**
-- TC0: `cum_ret_next = cum_ret + ret_next`
-- TC1: `ret_sq = ret * ret`
-- TC2: `cum_sq_next = cum_sq + ret_sq_next`
-- TC3: `trade_count` immutability
-- TC4: placeholder (dataset commitment)
+---
 
-**Boundary Constraints (4):**
-- BC0: `cum_ret[0] = ret[0]` (first row)
-- BC1: `cum_sq[0] = ret_sq[0]` (first row)
-- BC2: `cum_ret[N-1] = total_return` (last row)
-- BC3: `cum_ret² × SCALE - sharpe_sq × (n × cum_sq - cum_ret²) = 0` (last row)
+## Key Features
+
+- **STARK-verified Sharpe ratio** — no trusted setup, transparent security, post-quantum ready
+- **Real GMX V2 trade data** — pulls actual trades from Arbitrum One mainnet
+- **Arbitrum Stylus verifier** — Rust/WASM on-chain contract with native Keccak256 precompile
+- **Multi-receipt commitment binding** — binds proof to specific trade receipts via hash chain
+- **Browser WASM prover** — proof generation runs entirely client-side, no backend needed
+- **~1.25M gas verification** — full STARK proof verified on-chain in a single transaction
+
+---
+
+## Demo
+
+> Connect wallet → Enter trader address → View verified Sharpe ratio
+
+<!-- TODO: Add screenshot or GIF -->
+<!-- ![RealBot Demo](public/demo.gif) -->
+
+---
+
+## Technical Architecture
+
+### Sharpe Ratio AIR
+
+| Parameter | Value |
+|-----------|-------|
+| Trace columns | 6 — `[return, return_sq, cum_ret, cum_sq, trade_count, dataset_commitment]` |
+| Transition constraints | 5 — cumulative sum, squaring, immutability |
+| Boundary constraints | 4 — initial values, final Sharpe equation |
+| Composition alphas | 9 |
+| LDE blowup | 4x |
+| FRI queries | 4 (default) / 20 (full security) |
+
+### Constraint Details
+
+**Transition Constraints:**
+- TC0: `cum_ret[i+1] = cum_ret[i] + ret[i+1]`
+- TC1: `ret_sq[i] = ret[i] * ret[i]`
+- TC2: `cum_sq[i+1] = cum_sq[i] + ret_sq[i+1]`
+- TC3: `trade_count` immutability across rows
+- TC4: `dataset_commitment` immutability
+
+**Boundary Constraints:**
+- BC0: `cum_ret[0] = ret[0]`
+- BC1: `cum_sq[0] = ret_sq[0]`
+- BC2: `cum_ret[N-1] = total_return`
+- BC3: Sharpe equation — `cum_ret² * SCALE - sharpe_sq * (n * cum_sq - cum_ret²) = 0`
+
+### Cryptographic Stack
+
+| Component | Choice |
+|-----------|--------|
+| Hash | Keccak256 (native Stylus precompile) |
+| Field | BN254 scalar field (Montgomery form) |
+| Commitment | FRI + Keccak256 Merkle trees |
+| Fiat-Shamir | Keccak256-based channel |
+
+---
+
+## Performance Benchmarks
+
+| | STARK (RealBot) | SNARK (SP1 Groth16) |
+|--|:---:|:---:|
+| **Proof generation** | 380 ms | 18,500 ms |
+| **Proof size** | 4,864 bytes | 260 bytes |
+| **On-chain gas** | 1,250,000 | 280,000 |
+| **Verifier** | Stylus (WASM) | Solidity (Groth16) |
+| **Trusted setup** | None (transparent) | Required (SP1) |
+
+**Why STARK?** RealBot uses STARK over SNARK because:
+- **No trusted setup** — transparent security assumptions
+- **Keccak256 native** — Stylus precompile makes hash-heavy STARK verification efficient on-chain
+- **48x faster proof generation** — 380ms vs 18.5s matters for browser UX
 
 ---
 
@@ -85,17 +132,33 @@ ProofScore uses STARK proofs to verify trading agent performance (Sharpe ratio) 
 ### Prerequisites
 
 - **Node.js** 18+ / **pnpm**
-- **Rust** + cargo (for Stylus / prover)
+- **Rust** + cargo (for Stylus contract and prover)
 - **Foundry** (for Solidity EvaluationRegistry)
 
-### Installation
+### Run
 
 ```bash
-git clone https://github.com/hoddukzoa12/starkverifier.git
+git clone https://github.com/2026Arbitriumhackthon/starkverifier.git
 cd starkverifier
 pnpm install
 cp .env.example .env.local
 pnpm dev
+```
+
+### Test
+
+```bash
+# Stylus verifier (88 tests)
+cd contracts/stylus && cargo test --features export-abi
+
+# Off-chain prover (54 tests)
+cd prover && cargo test
+
+# Solidity registry
+cd contracts/solidity && forge test -vvv
+
+# Frontend
+pnpm test
 ```
 
 ### Generate a Proof
@@ -105,18 +168,14 @@ cd prover
 cargo run --features cli --release -- --bot a --num-queries 4
 ```
 
-### Run Tests
+---
 
-```bash
-# Stylus verifier (66 tests)
-cd contracts/stylus && cargo test --features export-abi
+## Deployed Contracts (Arbitrum Sepolia)
 
-# Prover (33 tests)
-cd prover && cargo test
-
-# Solidity (EvaluationRegistry)
-cd contracts/solidity && forge test -vvv
-```
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| **STARK Verifier v6** | [`0x365344c7057eee248c986e4170e143f0449d943e`](https://sepolia.arbiscan.io/address/0x365344c7057eee248c986e4170e143f0449d943e) | Sharpe ratio STARK verification + commitment binding |
+| EvaluationRegistry | TBD | On-chain agent evaluation records |
 
 ---
 
@@ -127,78 +186,33 @@ starkverifier/
 ├── contracts/
 │   ├── stylus/                  # On-chain STARK Verifier (Rust → WASM)
 │   │   └── src/
-│   │       ├── lib.rs          # Entry point (verifySharpeProof)
-│   │       ├── field.rs        # BN254 field arithmetic (Montgomery)
-│   │       ├── merkle.rs       # Keccak256 Merkle tree verification
-│   │       └── stark/
-│   │           ├── mod.rs      # Full Sharpe verifier orchestration
-│   │           ├── sharpe_air.rs # Sharpe AIR constraints + zerofier
-│   │           ├── channel.rs  # Fiat-Shamir (Keccak-based)
-│   │           ├── domain.rs   # Evaluation domains (roots of unity)
-│   │           ├── fri.rs      # FRI low-degree verifier
-│   │           └── proof.rs    # Proof deserialization
-│   │
-│   └── solidity/                # EvaluationRegistry (Solidity)
-│       └── src/
-│           └── EvaluationRegistry.sol
-│
+│   │       ├── lib.rs           # Entry: verifySharpeProof()
+│   │       ├── field.rs         # BN254 field arithmetic (Montgomery)
+│   │       ├── merkle.rs        # Keccak256 Merkle verification
+│   │       ├── mpt.rs           # MPT proof + commitment binding
+│   │       └── stark/           # AIR, FRI, channel, domain, proof
+│   └── solidity/                # EvaluationRegistry (Foundry)
 ├── prover/                      # Off-chain STARK Prover (Rust)
-│   └── src/
-│       ├── main.rs             # CLI: --bot a|b --num-queries N
-│       ├── lib.rs              # prove_sharpe() + shared utilities
-│       ├── sharpe_trace.rs     # Sharpe ratio trace generation
-│       ├── sharpe_compose.rs   # Composition polynomial on LDE
-│       ├── mock_data.rs        # Bot A / Bot B trade datasets
-│       ├── commit.rs           # Keccak Merkle tree construction
-│       ├── fri.rs              # FRI prover (fold + commit layers)
-│       ├── channel.rs          # Fiat-Shamir (matches on-chain)
-│       ├── domain.rs           # Evaluation domains
-│       ├── proof.rs            # Proof serialization (JSON / ABI)
-│       ├── field.rs            # BN254 field arithmetic
-│       ├── keccak.rs           # Keccak hash (matches on-chain)
-│       └── wasm.rs             # WASM bindings (wasm-bindgen)
-│
-├── app/                         # Next.js 16 Frontend
+│   ├── src/
+│   │   ├── lib.rs               # prove_sharpe()
+│   │   ├── sharpe_trace.rs      # Trace generation
+│   │   ├── sharpe_compose.rs    # Composition polynomial
+│   │   ├── fri.rs               # FRI prover
+│   │   ├── channel.rs           # Fiat-Shamir (matches on-chain)
+│   │   ├── gmx_fetcher.rs       # GMX V2 trade fetcher
+│   │   ├── receipt_proof.rs     # Receipt hash chain
+│   │   └── wasm.rs              # WASM bindings (wasm-bindgen)
+│   └── pkg/                     # Pre-built WASM package
+├── app/                         # Next.js 16 App Router
 ├── components/                  # React components (shadcn/ui)
-├── lib/                         # Contracts, chains, client
-└── package.json
+├── lib/                         # TypeScript utilities
+│   ├── wasm-prover.ts           # WASM prover loader
+│   ├── gmx-fetcher.ts           # GMX V2 trade fetcher
+│   ├── contracts.ts             # Addresses and ABIs
+│   └── benchmark-data.ts        # STARK vs SNARK comparison
+├── benchmark/                   # Benchmark tooling (STARK vs SP1)
+└── scripts/                     # Build and deploy scripts
 ```
-
----
-
-## Deployed Contracts (Arbitrum Sepolia)
-
-| Contract | Address | Purpose |
-|----------|---------|---------|
-| **STARK Verifier v4** | [`0x4709cc3862280597855a6986b13f1f1ccb309ff9`](https://sepolia.arbiscan.io/address/0x4709cc3862280597855a6986b13f1f1ccb309ff9) | Sharpe ratio STARK verification |
-| EvaluationRegistry | TBD | On-chain agent evaluation records |
-
----
-
-## Proof Interface
-
-```solidity
-interface IStarkVerifier {
-    function verifySharpeProof(
-        uint256[] calldata publicInputs,    // [trade_count, total_return, sharpe_sq_scaled, merkle_root]
-        uint256[] calldata commitments,      // [trace_root, comp_root, fri_roots...]
-        uint256[] calldata oodValues,        // [6 trace(z), 6 trace(zg), comp(z)] = 13 values
-        uint256[] calldata friFinalPoly,     // Final polynomial coefficients
-        uint256[] calldata queryValues,      // FRI query evaluations (flattened)
-        uint256[] calldata queryPaths,       // Merkle auth paths (flattened)
-        uint256[] calldata queryMetadata     // [num_queries, num_fri_layers, log_trace_len, indices...]
-    ) external returns (bool);
-}
-```
-
----
-
-## Gas Benchmarks
-
-| Bot | Trades | Queries | Gas Used |
-|-----|--------|---------|----------|
-| Bot A (Aggressive ETH) | 15 | 4 | ~1.25M |
-| Bot B (Safe Hedger) | 23 | 4 | ~1.45M |
 
 ---
 
@@ -208,21 +222,181 @@ interface IStarkVerifier {
 |-------|-----------|
 | On-chain verifier | Rust → WASM (Arbitrum Stylus SDK 0.9) |
 | On-chain registry | Solidity 0.8.24 (Foundry) |
-| Off-chain prover | Rust (CLI + WASM) |
+| Off-chain prover | Rust → WASM (wasm-pack, wasm-bindgen) |
 | Hash function | Keccak256 (native Stylus precompile) |
-| Field | BN254 scalar field |
-| Frontend | Next.js 16, thirdweb v5, shadcn/ui |
+| Field | BN254 scalar field (Montgomery form) |
+| Frontend | Next.js 16, React 19, thirdweb v5, shadcn/ui |
+
+---
+
+## Security Model
+
+### Phase A (Current) — Commitment Binding
+
+The prover commits to specific trade data via a **receipt hash chain**. The on-chain verifier checks that the STARK proof is bound to this commitment, preventing proof reuse or data substitution after the fact.
+
+### Roadmap — Full Data Verification
+
+- Encode GMX V2 event decoding inside the STARK circuit
+- Verify Merkle Patricia Trie (MPT) membership proofs for Arbitrum receipts
+- Achieve fully trustless data binding without any off-chain assumptions
 
 ---
 
 ## Environment Variables
 
 ```env
-NEXT_PUBLIC_THIRDWEB_CLIENT_ID   # Required for frontend
-PRIVATE_KEY                       # For contract deployment
-ARBITRUM_SEPOLIA_RPC_URL          # Optional RPC override
-ARBISCAN_API_KEY                  # Optional for verification
+# Required (Frontend)
+NEXT_PUBLIC_THIRDWEB_CLIENT_ID=your_thirdweb_client_id
+
+# Required for contract deployment
+PRIVATE_KEY=your_wallet_private_key
+
+# Optional
+ARBITRUM_SEPOLIA_RPC_URL=https://sepolia-rollup.arbitrum.io/rpc
+ARBISCAN_API_KEY=your_arbiscan_api_key
 ```
+
+---
+
+## Why Stylus for STARK Verification
+
+STARK proofs are **hash-heavy** — the verifier re-hashes Merkle paths, FRI commitments, and Fiat-Shamir challenges hundreds of times per proof. Arbitrum Stylus compiles Rust to WASM and runs it natively on the Arbitrum chain, giving significant advantages over Solidity/EVM for this workload.
+
+### EVM vs Stylus (WASM) Comparison
+
+| Dimension | EVM (Solidity) | Stylus (WASM) |
+|-----------|:--------------:|:-------------:|
+| **Register size** | 256-bit stack machine | 64-bit register machine |
+| **Loop overhead** | ~8 gas per iteration (JUMP+JUMPDEST) | ~0.1 gas equivalent (native branch) |
+| **Memory model** | Linear, 3 gas/byte expansion | Linear, ~0.5 gas/byte |
+| **Keccak256** | 30 gas + 6 gas/word (EVM opcode) | **Native precompile** (host I/O) |
+| **Arithmetic** | 256-bit only (no native u64) | Native u64 multiply and modular ops |
+
+### Why This Matters for STARK
+
+A single STARK verification call requires:
+- **~200+ Keccak256 hashes** — Merkle path verification for each FRI query across all layers
+- **~500+ field multiplications** — constraint evaluation, polynomial interpolation, domain operations
+- **Tight loops** — FRI fold operations iterate over query data repeatedly
+
+Stylus turns these into native WASM operations with the Keccak256 precompile eliminating the biggest bottleneck. The result: **~1.25M gas** for full STARK verification — feasible in a single Arbitrum transaction.
+
+---
+
+## Contract Deployment
+
+### Stylus Verifier (Rust → WASM)
+
+```bash
+cd contracts/stylus
+
+# Validate WASM contract against Stylus constraints
+cargo stylus check
+
+# Deploy to Arbitrum Sepolia (requires funded wallet)
+cargo stylus deploy --private-key $PRIVATE_KEY
+```
+
+### Solidity EvaluationRegistry (Foundry)
+
+```bash
+cd contracts/solidity
+
+# Build
+forge build
+
+# Deploy via script
+forge script script/Deploy.s.sol:Deploy \
+  --rpc-url $ARBITRUM_SEPOLIA_RPC_URL \
+  --private-key $PRIVATE_KEY \
+  --broadcast
+```
+
+---
+
+## Proof Interface (Solidity ABI)
+
+The Stylus contract exposes a single verification function. Rust snake_case is auto-converted to Solidity camelCase by the Stylus SDK.
+
+```solidity
+function verifySharpeProof(
+    uint256[] calldata publicInputs,    // [trade_count, total_return, sharpe_sq_scaled, merkle_root]
+    uint256[] calldata commitments,     // [trace_root, comp_root, fri_roots...]
+    uint256[] calldata oodValues,       // [6 trace(z), 6 trace(zg), comp(z)] = 13 values
+    uint256[] calldata friFinalPoly,    // Final polynomial coefficients
+    uint256[] calldata queryValues,     // Flattened query data per FRI layer
+    uint256[] calldata queryPaths,      // Flattened Merkle authentication paths
+    uint256[] calldata queryMetadata    // [num_queries, num_fri_layers, log_trace_len, indices...]
+) external view returns (bool);
+```
+
+### Parameter Details
+
+| Parameter | Description |
+|-----------|-------------|
+| `publicInputs` | Public values the verifier checks against — trade count, total return, scaled Sharpe², and the dataset commitment (receipt Merkle root) |
+| `commitments` | Merkle roots for trace, composition, and each FRI layer — binds the prover to specific polynomials |
+| `oodValues` | Out-of-domain evaluations at random point `z` — used to check AIR constraints without opening the full polynomial |
+| `friFinalPoly` | Coefficients of the final low-degree polynomial after FRI folding — verifier checks degree bound |
+| `queryValues` | Decommitted values at randomly sampled positions across all FRI layers |
+| `queryPaths` | Merkle authentication paths for each query value — proves membership in committed trees |
+| `queryMetadata` | Structural metadata: number of queries, FRI layers, trace length, and the query indices themselves |
+
+---
+
+## Future Plan
+
+### Phase B — MPT Receipt Proof
+Verify **Merkle Patricia Trie (MPT) membership proofs** for Arbitrum transaction receipts inside the STARK circuit. This achieves fully trustless data binding: the verifier can confirm that trade data came from a specific L1 batch without any off-chain trust assumption.
+
+### Phase C — In-Circuit Event Decoding
+Decode **GMX V2 event logs** (PositionIncrease, PositionDecrease) directly inside the STARK arithmetic circuit. Combined with Phase B, this creates an end-to-end trustless pipeline from raw blockchain state to verified Sharpe ratio.
+
+### Multi-DEX Support
+Extend beyond GMX V2 to support trade data from **Uniswap V3**, **dYdX**, and other DEXs on Arbitrum. Each DEX gets an event decoder module that feeds into the same Sharpe ratio AIR.
+
+### EvaluationRegistry Integration
+Record verified Sharpe scores in the on-chain **EvaluationRegistry** contract. Enable agent ranking, historical performance tracking, and composable reputation scores that other protocols can query.
+
+### Mainnet Deployment
+Migrate from Arbitrum Sepolia to **Arbitrum One mainnet**. Optimize gas costs and conduct security audits before production deployment.
+
+### Additional Metrics
+Expand the proof system beyond Sharpe ratio to include:
+- **Sortino Ratio** — downside-risk-adjusted return
+- **Maximum Drawdown** — largest peak-to-trough decline
+- **Calmar Ratio** — return relative to max drawdown
+- **Win Rate** — percentage of profitable trades
+
+Each metric gets its own AIR constraint set while sharing the FRI and commitment infrastructure.
+
+---
+
+## Contributing
+
+Contributions are welcome! Please follow the standard fork-and-PR workflow:
+
+1. **Fork** the repository
+2. **Create a branch** — `git checkout -b feature/your-feature`
+3. **Make your changes** and add tests where applicable
+4. **Run tests** — `cargo test --features export-abi` (Stylus) / `cargo test` (prover) / `pnpm test` (frontend)
+5. **Push** — `git push origin feature/your-feature`
+6. **Open a Pull Request** against `main`
+
+Please open an issue first for major changes to discuss the approach.
+
+---
+
+## References
+
+- [Arbitrum Stylus Documentation](https://docs.arbitrum.io/stylus/gentle-introduction) — Stylus SDK, WASM contract development
+- [Arbitrum Stylus SDK (Rust)](https://github.com/OffchainLabs/stylus-sdk-rs) — Rust SDK for Stylus contracts
+- [STARKs, Part I: Proofs with Polynomials](https://vitalik.eth.limo/general/2017/11/09/starks_part_1.html) — Vitalik Buterin's STARK explainer
+- [ethSTARK Documentation](https://eprint.iacr.org/2021/582) — STARK protocol specification
+- [FRI Protocol](https://eccc.weizmann.ac.il/report/2017/134/) — Fast Reed-Solomon Interactive Oracle Proofs of Proximity
+- [thirdweb React SDK](https://portal.thirdweb.com/react/v5) — Wallet connection and contract interaction
+- [GMX V2 Documentation](https://docs.gmx.io/) — Trade event structure and subgraph API
 
 ---
 
@@ -233,5 +407,5 @@ MIT License — see [LICENSE](LICENSE) for details.
 ---
 
 <p align="center">
-  Built for <strong>Arbitrum Buildathon 2026</strong>
+  Built for <strong>Arbitrum Open House NYC: Online Buildathon</strong>
 </p>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "ProofScore | On-Chain Agent Evaluation",
+  title: "RealBot | On-Chain Agent Evaluation",
   description:
     "STARK-verified trading agent evaluation on Arbitrum Stylus. Sharpe ratio proofs with zero-knowledge guarantees.",
   keywords: [
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
   ],
   authors: [{ name: "hodduk" }],
   openGraph: {
-    title: "ProofScore | On-Chain Agent Evaluation",
+    title: "RealBot | On-Chain Agent Evaluation",
     description: "STARK-verified trading agent evaluation on Arbitrum Stylus",
     type: "website",
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
               <div>
                 <h1 className="text-xl font-bold">STARK Stylus Verifier</h1>
                 <p className="text-xs text-muted-foreground">
-                  ProofScore — On-Chain Agent Evaluation
+                  RealBot — On-Chain Agent Evaluation
                 </p>
               </div>
             </div>
@@ -36,7 +36,7 @@ export default function Home() {
         <div className="container mx-auto px-4 py-12">
           <div className="max-w-3xl mx-auto text-center space-y-4">
             <Badge className="bg-gradient-to-r from-orange-500 to-purple-600">
-              Arbitrum APAC Mini Hackathon 2026
+              Arbitrum Open House NYC: Online Buildathon
             </Badge>
             <h2 className="text-4xl sm:text-5xl font-bold tracking-tight">
               On-Chain{" "}
@@ -134,11 +134,11 @@ export default function Home() {
         <div className="container mx-auto px-4 py-8">
           <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
             <p className="text-sm text-muted-foreground">
-              Built for Arbitrum APAC Mini Hackathon 2026
+              Built for Arbitrum Open House NYC: Online Buildathon
             </p>
             <div className="flex items-center gap-4">
               <a
-                href="https://github.com/hoddukzoa12/starkverifier.git"
+                href="https://github.com/2026Arbitriumhackthon/starkverifier.git"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"

--- a/components/AgentDashboard.tsx
+++ b/components/AgentDashboard.tsx
@@ -169,7 +169,7 @@ export function AgentDashboard() {
   return (
     <section className="container mx-auto px-4 py-12 space-y-8">
       <div className="text-center space-y-2">
-        <h3 className="text-2xl font-bold">ProofScore Dashboard</h3>
+        <h3 className="text-2xl font-bold">RealBot Dashboard</h3>
         <p className="text-muted-foreground">
           Select a trading agent and verify its Sharpe ratio on-chain with STARK proofs.
         </p>


### PR DESCRIPTION
## Summary
- Replace all "ProofScore" references with "RealBot" in frontend (metadata title, OG title, header subtitle, dashboard heading)
- Update hackathon name from "Arbitrum APAC Mini Hackathon 2026" to "Arbitrum Open House NYC: Online Buildathon"
- Update CLAUDE.md project description for consistency

## Changed files
- `app/layout.tsx` — metadata title, openGraph title
- `app/page.tsx` — header subtitle, hero badge, footer text
- `components/AgentDashboard.tsx` — dashboard heading
- `CLAUDE.md` — project overview

## Test plan
- [ ] `pnpm dev` — verify browser tab shows "RealBot"
- [ ] Verify no "ProofScore" text visible on any page
- [ ] Verify hackathon name displays correctly in hero badge and footer